### PR TITLE
Typecast long id to int will cause issue.

### DIFF
--- a/src/Pinterest/Api.php
+++ b/src/Pinterest/Api.php
@@ -452,7 +452,7 @@ class Api
         }
 
         $params = array(
-            'board' => (int) $boardId,
+            'board' => $boardId,
             'note' => (string) $note,
         );
 


### PR DESCRIPTION
The current pintrest id's having length like this one
(641763084339350760). The typecasting will lead this number to
2147483647 as this is max value of integer type.
So removed typecasting.

You can check following php code for reference
```
<?php
    $number = '641763084339350760';
    echo $number.'<br/>';
    echo (int)$number.'<br/>';
?>
```