### PR TITLE
Remove the Creator field from Board objects

### DIFF
--- a/src/Pinterest/Objects/Board.php
+++ b/src/Pinterest/Objects/Board.php
@@ -32,7 +32,6 @@ final class Board implements BaseObject
             'name',
             'url',
             'description',
-            'creator',
             'created_at',
             'counts',
             'image',
@@ -67,13 +66,6 @@ final class Board implements BaseObject
      * @var string
      */
     public $description;
-
-    /**
-     * The user who created the board.
-     *
-     * @var User
-     */
-    public $creator;
 
     /**
      * ISO 8601 Timestamp of creation date.


### PR DESCRIPTION
It seems Pinterest deprecated the `creator` field for `Board` objects.
This commit makes it so that we don't query the API for that deprecated
field, resulting in errors.

closes #43