### PR TITLE
Remove creator field from Pin objects

### DIFF
--- a/src/Pinterest/Objects/Pin.php
+++ b/src/Pinterest/Objects/Pin.php
@@ -31,7 +31,6 @@ final class Pin implements BaseObject
             'id',
             'link',
             'url',
-            'creator',
             'board',
             'created_at',
             'note',
@@ -65,13 +64,6 @@ final class Pin implements BaseObject
      * @var string
      */
     public $url;
-
-    /**
-     * The user who created the pin.
-     *
-     * @var User
-     */
-    public $creator;
 
     /**
      * The board the Pin is in.


### PR DESCRIPTION
As in https://github.com/hansott/pinterest-php/pull/44 this also needs to change for Pin objects, as the documentation states https://developers.pinterest.com/docs/api/pins/