### PR TITLE
Add check to ratelimit on requestAccessToken call.

### DIFF
--- a/src/Pinterest/Authentication.php
+++ b/src/Pinterest/Authentication.php
@@ -20,6 +20,7 @@ use Pinterest\Api\Exceptions\TokenMissing;
 use Pinterest\Api\Exceptions\TooManyScopesGiven;
 use Pinterest\Api\Exceptions\AtLeastOneScopeNeeded;
 use Pinterest\Api\Exceptions\InvalidScopeException;
+use Pinterest\Http\Exceptions\RateLimitedReached;
 
 /**
  * This class is responsible for authenticating requests.
@@ -199,6 +200,7 @@ final class Authentication implements ClientInterface
      * @return string The OAuth access token.
      *
      * @throws TokenMissing
+     * @throws RateLimitedReached
      */
     public function requestAccessToken($code)
     {
@@ -214,6 +216,10 @@ final class Authentication implements ClientInterface
         );
 
         $response = $this->http->execute($request);
+
+        if($response->rateLimited()) {
+            throw new RateLimitedReached($response);
+        }
 
         if (
             !isset($response->body)

--- a/src/Pinterest/Authentication.php
+++ b/src/Pinterest/Authentication.php
@@ -217,7 +217,7 @@ final class Authentication implements ClientInterface
 
         $response = $this->http->execute($request);
 
-        if($response->rateLimited()) {
+        if ($response->rateLimited()) {
             throw new RateLimitedReached($response);
         }
 


### PR DESCRIPTION
During development of our Pinterest App we keep running into the pretty heavy rate limiter of 10 request per hour. The call to the requestAccessToken() can also return this error but there is no check for that right now so you end with the TokenMissing exception which is also true but less specific.  